### PR TITLE
Fix to ignore httplib2 in string extraction

### DIFF
--- a/main/translations/babel.cfg
+++ b/main/translations/babel.cfg
@@ -1,3 +1,4 @@
+[ignore: **/httplib2/**.py]
 [python: **.py]
 [jinja2: templates/**.html]
 extensions=jinja2.ext.autoescape,jinja2.ext.with_


### PR DESCRIPTION
This resolves the https://github.com/gae-init/gae-init-babel/issues/5 "Bad gettext in httplib2 leading to untranslatable strings" issue, by adding `[ignore: **/httplib2/**.py]` to the `main/translations/babel.cfg` configuration file. Note that order of the patterns seems to be important in the `babel.cfg` file.
