### PR TITLE
Fixed: Flash message on login not always translated

### DIFF
--- a/main/auth.py
+++ b/main/auth.py
@@ -27,7 +27,6 @@ def check_locale(locale):
   locale = locale.lower()
   if locale in config.LOCALE:
     return locale
-  print '-'*5, locale, config.LOCALE_DEFAULT
   return config.LOCALE_DEFAULT
 
 


### PR DESCRIPTION
Fixed https://github.com/gae-init/gae-init-babel/issues/11 _"Flash message on login not always translated"_
