### PR TITLE
Ignoring html5lib for translations

### DIFF
--- a/main/translations/babel.cfg
+++ b/main/translations/babel.cfg
@@ -1,3 +1,4 @@
+[ignore: **/html5lib/**.py]
 [ignore: **/httplib2/**.py]
 [python: **.py]
 [jinja2: templates/**.html]


### PR DESCRIPTION
Though the messages in html5lib are properly marked for translation, I could not find any existing translations yet. As there are many (technical) messages, I propose to ignore it (for the time being, similar to httplib2).
