### PR TITLE
Making locale explicitly non-indexed

### DIFF
--- a/main/model.py
+++ b/main/model.py
@@ -36,7 +36,7 @@ class Config(Base, modelx.ConfigX):
   facebook_app_secret = ndb.StringProperty(default='')
   feedback_email = ndb.StringProperty(default='')
   flask_secret_key = ndb.StringProperty(default=util.uuid())
-  locale = ndb.StringProperty(default='en')
+  locale = ndb.StringProperty(indexed=False, default='en')
   twitter_consumer_key = ndb.StringProperty(default='')
   twitter_consumer_secret = ndb.StringProperty(default='')
 


### PR DESCRIPTION
Making `User.locale` explicitly non-indexed, to avoid any index to be created for this property.

According to https://developers.google.com/appengine/docs/python/ndb/properties such index might be created as needed: with `StringProperty` described as an "Unicode string; up to 500 characters, indexed"

Now, I haven't seen an index using `locale` (in `index.yaml`) during testing, but I think this property can safely be said to be unindexed.
