### PR TITLE
Welcome guests in their locale based on browser preference

### DIFF
--- a/main/auth.py
+++ b/main/auth.py
@@ -33,7 +33,11 @@ def check_locale(locale):
 def get_locale():
   locale = flask.session.pop('locale', None)
   if not locale:
-    locale = flask.request.cookies.get('locale', config.LOCALE_DEFAULT)
+    locale = flask.request.cookies.get('locale', None)
+    if not locale:
+      locale = flask.request.accept_languages.best_match(
+        matches=config.LOCALE.keys(),
+        default=config.LOCALE_DEFAULT)
   return check_locale(locale)
 
 


### PR DESCRIPTION
Select language based on browser preference (as transmitted in Accept-Languages header) of guests, or not yet logged in users. That is: when there is no session, URL, or cookie expressed locale (yet).

When the guest/visitor preference is not matched, the config based default locale is used (as before).
