### PR TITLE
Make link to localized Gravatar information

### DIFF
--- a/main/templates/profile.html
+++ b/main/templates/profile.html
@@ -29,7 +29,7 @@
           </div>
           <p class="help-block">
             {{_('Change on')}}
-            <a href="//gravatar.com" target="_blank">{{_('Gravatar')}}</a>
+            <a href="//{{request.locale}}.gravatar.com" target="_blank">{{_('Gravatar')}}</a>
           </p>
         </div>
       </div>


### PR DESCRIPTION
There might be a problem when locale isn't supported by Gravatar... like http://xx.gravatar.com doesn't resolve, but for the ones in `gae-init` it works (and for 'nl' also).
