### PR TITLE
Updated run.py for bower package mngmnt and babel

### DIFF
--- a/run.py
+++ b/run.py
@@ -8,6 +8,7 @@ import os
 import shutil
 import sys
 import time
+import urllib2
 
 from main import config
 
@@ -15,109 +16,100 @@ from main import config
 ###############################################################################
 # Options
 ###############################################################################
-parser = argparse.ArgumentParser()
-parser.add_argument(
+PARSER = argparse.ArgumentParser()
+PARSER.add_argument(
     '-w', '--watch', dest='watch', action='store_true',
     help='watch files for changes when running the development web server',
   )
-parser.add_argument(
+PARSER.add_argument(
     '-c', '--clean', dest='clean', action='store_true',
     help='''recompiles files when running the development web server, but
     obsolete if -s is used''',
   )
-parser.add_argument(
+PARSER.add_argument(
+    '-C', '--clean-all', dest='clean_all', action='store_true',
+    help='''Cleans all the Node & Bower related tools / libraries and updates
+    them to their latest versions''',
+  )
+PARSER.add_argument(
     '-m', '--minify', dest='minify', action='store_true',
     help='compiles files into minified version before deploying'
   )
-parser.add_argument(
+PARSER.add_argument(
     '-s', '--start', dest='start', action='store_true',
     help='starts the dev_appserver.py with storage_path pointing to temp',
   )
-parser.add_argument(
+PARSER.add_argument(
     '-o', '--host', dest='host', action='store', default='127.0.0.1',
     help='the host to start the dev_appserver.py',
   )
-parser.add_argument(
+PARSER.add_argument(
     '-p', '--port', dest='port', action='store', default='8080',
     help='the port to start the dev_appserver.py',
   )
-parser.add_argument(
+PARSER.add_argument(
     '-f', '--flush', dest='flush', action='store_true',
     help='clears the datastore, blobstore, etc',
   )
-parser.add_argument(
-    '-i', '--pybabel-init', dest='init', action='store_true',
+PARSER.add_argument(
+    '-i', '--pybabel-init', dest='pybabel_init_missing', action='store_true',
     help='''create new message catalogs from messages.pot that are defined
     in config.py and still not present (pybabel init..)''',
   )
-parser.add_argument(
+PARSER.add_argument(
+    '-l', '--pybabel-init-locale', dest='pybabel_locale', action='store',
+    help='create new message catalogs from messages.pot (pybabel init..)',
+  )
+PARSER.add_argument(
     '-u', '--pybabel-update', dest='pybabel_update', action='store_true',
     help='''extracts messages from source files to generate messages.pot
     (pybabel extract..) and updates existing catalogs (pybabel update..)''',
   )
-parser.add_argument(
+PARSER.add_argument(
     '-b', '--pybabel-compile', dest='pybabel_compile', action='store_true',
     help='compile message catalogs to MO files (pybabel compile..)',
   )
-parser.add_argument(
-    '-l', '--pybabel-init-locale', dest='locale', action='store',
-    help='create new message catalogs from messages.pot (pybabel init..)',
-  )
-args = parser.parse_args()
+ARGS = PARSER.parse_args()
 
 
 ###############################################################################
 # Directories
 ###############################################################################
+DIR_BOWER_COMPONENTS = 'bower_components'
 DIR_MAIN = 'main'
-DIR_STATIC = 'static'
-DIR_SRC = 'src'
+DIR_NODE_MODULES = 'node_modules'
 DIR_STYLE = 'style'
 DIR_SCRIPT = 'script'
-DIR_MIN = 'min'
-DIR_DST = 'dst'
-DIR_LIB = 'lib'
-DIR_NODE_MODULES = 'node_modules'
-DIR_BIN = '.bin'
 DIR_TEMP = 'temp'
-DIR_STORAGE = 'storage'
-DIR_TRANSLATIONS = 'translations'
 
-FILE_ZIP = '%s.zip' % DIR_LIB
-FILE_COFFEE = 'coffee'
-FILE_LESS = 'lessc'
-FILE_UGLIFYJS = 'uglifyjs'
+DIR_STATIC = os.path.join(DIR_MAIN, 'static')
 
-FILE_BABEL_CFG = 'babel.cfg'
-FILE_MESSAGES_POT = 'messages.pot'
+DIR_SRC = os.path.join(DIR_STATIC, 'src')
+DIR_SRC_SCRIPT = os.path.join(DIR_SRC, DIR_SCRIPT)
+DIR_SRC_STYLE = os.path.join(DIR_SRC, DIR_STYLE)
 
-dir_static = os.path.join(DIR_MAIN, DIR_STATIC)
+DIR_DST = os.path.join(DIR_STATIC, 'dst')
+DIR_DST_STYLE = os.path.join(DIR_DST, DIR_STYLE)
+DIR_DST_SCRIPT = os.path.join(DIR_DST, DIR_SCRIPT)
 
-dir_src = os.path.join(dir_static, DIR_SRC)
-dir_src_script = os.path.join(dir_src, DIR_SCRIPT)
-dir_src_style = os.path.join(dir_src, DIR_STYLE)
+DIR_MIN = os.path.join(DIR_STATIC, 'min')
+DIR_MIN_STYLE = os.path.join(DIR_MIN, DIR_STYLE)
+DIR_MIN_SCRIPT = os.path.join(DIR_MIN, DIR_SCRIPT)
 
-dir_dst = os.path.join(dir_static, DIR_DST)
-dir_dst_style = os.path.join(dir_dst, DIR_STYLE)
-dir_dst_script = os.path.join(dir_dst, DIR_SCRIPT)
+DIR_LIB = os.path.join(DIR_MAIN, 'lib')
+FILE_LIB = os.path.join(DIR_MAIN, 'lib.zip')
 
-dir_min = os.path.join(dir_static, DIR_MIN)
-dir_min_style = os.path.join(dir_min, DIR_STYLE)
-dir_min_script = os.path.join(dir_min, DIR_SCRIPT)
+DIR_BIN = os.path.join(DIR_NODE_MODULES, '.bin')
+FILE_COFFEE = os.path.join(DIR_BIN, 'coffee')
+FILE_GRUNT = os.path.join(DIR_BIN, 'grunt')
+FILE_LESS = os.path.join(DIR_BIN, 'lessc')
+FILE_UGLIFYJS = os.path.join(DIR_BIN, 'uglifyjs')
 
-dir_lib = os.path.join(DIR_MAIN, DIR_LIB)
-file_lib = os.path.join(DIR_MAIN, FILE_ZIP)
+DIR_STORAGE = os.path.join(DIR_TEMP, 'storage')
 
-dir_bin = os.path.join(DIR_NODE_MODULES, DIR_BIN)
-file_coffee = os.path.join(dir_bin, FILE_COFFEE)
-file_less = os.path.join(dir_bin, FILE_LESS)
-file_uglifyjs = os.path.join(dir_bin, FILE_UGLIFYJS)
-
-dir_storage = os.path.join(DIR_TEMP, DIR_STORAGE)
-
-dir_translations = os.path.join(DIR_MAIN, DIR_TRANSLATIONS)
-file_babel_cfg = os.path.join(dir_translations, FILE_BABEL_CFG)
-file_messages_pot = os.path.join(dir_translations, FILE_MESSAGES_POT)
+DIR_TRANSLATIONS = os.path.join(DIR_MAIN, 'translations')
+FILE_BABEL_CFG = os.path.join(DIR_TRANSLATIONS, 'babel.cfg')
+FILE_MESSAGES_POT = os.path.join(DIR_TRANSLATIONS, 'messages.pot')
 
 
 ###############################################################################
@@ -147,11 +139,11 @@ def clean_files():
       'CLEAN FILES',
       'Removing files: %s' % ', '.join(['*%s' % e for e in bad_endings]),
     )
-  for home, dirs, files in os.walk('.'):
-    for f in files:
-      for b in bad_endings:
-        if f.endswith(b):
-          os.remove(os.path.join(home, f))
+  for root, _, files in os.walk('.'):
+    for filename in files:
+      for bad_ending in bad_endings:
+        if filename.endswith(bad_ending):
+          os.remove(os.path.join(root, filename))
 
 
 def merge_files(source, target):
@@ -171,7 +163,7 @@ def compile_script(source, target_dir):
     print_out('NOT FOUND', source)
     return
 
-  target = source.replace(dir_src_script, target_dir).replace('.coffee', '.js')
+  target = source.replace(DIR_SRC_SCRIPT, target_dir).replace('.coffee', '.js')
   if not is_dirty(source, target):
     return
   make_dirs(os.path.dirname(target))
@@ -180,7 +172,7 @@ def compile_script(source, target_dir):
     shutil.copy(source, target)
     return
   print_out('COFFEE', source)
-  os_execute(file_coffee, '-cp', source, target)
+  os_execute(FILE_COFFEE, '-cp', source, target)
 
 
 def compile_style(source, target_dir, check_modified=False):
@@ -188,14 +180,14 @@ def compile_style(source, target_dir, check_modified=False):
     print_out('NOT FOUND', source)
     return
 
-  target = source.replace(dir_src_style, target_dir).replace('.less', '.css')
+  target = source.replace(DIR_SRC_STYLE, target_dir).replace('.less', '.css')
   minified = ''
   if not source.endswith('.less'):
     return
   if check_modified and not is_style_modified(target):
     return
 
-  if target_dir == dir_min_style:
+  if target_dir == DIR_MIN_STYLE:
     minified = '-x'
     target = target.replace('.css', '.min.css')
     print_out('LESS MIN', source)
@@ -203,15 +195,15 @@ def compile_style(source, target_dir, check_modified=False):
     print_out('LESS', source)
 
   make_dirs(os.path.dirname(target))
-  os_execute(file_less, minified, source, target)
+  os_execute(FILE_LESS, minified, source, target)
 
 
 def make_lib_zip(force=False):
-  if force and os.path.isfile(file_lib):
-    os.remove(file_lib)
-  if not os.path.isfile(file_lib):
-    print_out('ZIP', file_lib)
-    shutil.make_archive(dir_lib, 'zip', dir_lib)
+  if force and os.path.isfile(FILE_LIB):
+    os.remove(FILE_LIB)
+  if not os.path.isfile(FILE_LIB):
+    print_out('ZIP', FILE_LIB)
+    shutil.make_archive(DIR_LIB, 'zip', DIR_LIB)
 
 
 def is_dirty(source, target):
@@ -221,9 +213,9 @@ def is_dirty(source, target):
 
 
 def is_style_modified(target):
-  for folder, folders, files in os.walk(dir_src):
-    for file_ in files:
-      path = os.path.join(folder, file_)
+  for root, _, files in os.walk(DIR_SRC):
+    for filename in files:
+      path = os.path.join(root, filename)
       if path.endswith('.less') and is_dirty(path, target):
         return True
   return False
@@ -231,10 +223,10 @@ def is_style_modified(target):
 
 def compile_all_dst():
   for source in config.STYLES:
-    compile_style(os.path.join(dir_static, source), dir_dst_style, True)
+    compile_style(os.path.join(DIR_STATIC, source), DIR_DST_STYLE, True)
   for module in config.SCRIPTS:
     for source in config.SCRIPTS[module]:
-      compile_script(os.path.join(dir_static, source), dir_dst_script)
+      compile_script(os.path.join(DIR_STATIC, source), DIR_DST_SCRIPT)
 
 
 def update_path_separators():
@@ -249,32 +241,40 @@ def update_path_separators():
       config.SCRIPTS[module][idx] = fixit(config.SCRIPTS[module][idx])
 
 
-def install_dependencies():
-  missing = False
-  if not os.path.exists(file_coffee):
-    missing = True
-  if not os.path.exists(file_less):
-    missing = True
-  if not os.path.exists(file_uglifyjs):
-    missing = True
-  if not os.path.exists(os.path.join(DIR_NODE_MODULES, 'grunt')):
-    missing = True
+def internet_on():
   try:
-    file_package = os.path.join(DIR_NODE_MODULES, 'uglify-js', 'package.json')
-    package_json = json.load(open(file_package))
-    version = package_json['version']
-    if int(version.split('.')[0]) < 2:
-      missing = True
-  except:
-    missing = True
+    urllib2.urlopen('http://74.125.228.100', timeout=1)
+    return True
+  except urllib2.URLError:
+    return False
 
-  if missing:
-    os.system('npm install')
+
+def get_dependencies(file_name):
+  with open(file_name) as json_file:
+    json_data = json.load(json_file)
+  dependencies = json_data.get('dependencies', dict()).keys()
+  return dependencies + json_data.get('devDependencies', dict()).keys()
+
+
+def install_dependencies():
+  if not internet_on():
+    print_out('NO INTERNET')
+    return
+
+  for dependency in get_dependencies('package.json'):
+    if not os.path.exists(os.path.join(DIR_NODE_MODULES, dependency)):
+      os.system('npm install')
+      break
+
+  for dependency in get_dependencies('bower.json'):
+    if not os.path.exists(os.path.join(DIR_BOWER_COMPONENTS, dependency)):
+      os.system('"%s" bower' % FILE_GRUNT)
+      break
 
 
 def update_missing_args():
-  if args.start:
-    args.clean = True
+  if ARGS.start or ARGS.clean_all:
+    ARGS.clean = True
 
 
 def uniq(seq):
@@ -287,113 +287,91 @@ def uniq(seq):
 ###############################################################################
 def pybabel_extract():
   os.system('"pybabel" extract -k _ -k __ -F %s --sort-by-file --omit-header -o %s %s' % (
-      file_babel_cfg, file_messages_pot, DIR_MAIN,
+      FILE_BABEL_CFG, FILE_MESSAGES_POT, DIR_MAIN,
     ))
 
 
 def pybabel_update():
   os.system('"pybabel" update -i %s -d %s --no-wrap' % (
-      file_messages_pot, dir_translations,
+      FILE_MESSAGES_POT, DIR_TRANSLATIONS,
     ))
 
 
 def pybabel_init(locale):
   os.system('"pybabel" init -i %s -d %s -l %s' % (
-      file_messages_pot, dir_translations, locale,
+      FILE_MESSAGES_POT, DIR_TRANSLATIONS, locale,
     ))
 
 
 def pybabel_init_missing():
-  if not os.path.exists(os.path.join(dir_translations, 'messages.pot')):
+  if not os.path.exists(FILE_MESSAGES_POT):
     pybabel_extract()
   for locale in config.LOCALE:
-    msg = os.path.join(dir_translations, locale, 'LC_MESSAGES', 'messages.po')
+    msg = os.path.join(DIR_TRANSLATIONS, locale, 'LC_MESSAGES', 'messages.po')
     if not os.path.exists(msg):
       pybabel_init(locale)
 
 
 def pybabel_compile():
-  os.system('"pybabel" compile -f -d %s' % (dir_translations))
+  os.system('"pybabel" compile -f -d %s' % (DIR_TRANSLATIONS))
 
 
 ###############################################################################
 # Main
 ###############################################################################
-os.chdir(os.path.dirname(os.path.realpath(__file__)))
-
-update_path_separators()
-install_dependencies()
-update_missing_args()
-
-if len(sys.argv) == 1:
-  parser.print_help()
-  sys.exit(1)
-
-if args.clean:
+def run_clean():
   print_out('CLEAN')
   clean_files()
   make_lib_zip(force=True)
-  remove_dir(dir_dst)
-  make_dirs(dir_dst)
+  remove_dir(DIR_DST)
+  make_dirs(DIR_DST)
   compile_all_dst()
   print_out('DONE')
 
-if args.minify:
+
+def run_clean_all():
+  print_out('CLEAN ALL')
+  remove_dir(DIR_BOWER_COMPONENTS)
+  remove_dir(DIR_NODE_MODULES)
+
+
+def run_minify():
   print_out('MINIFY')
   clean_files()
   make_lib_zip(force=True)
-  remove_dir(dir_min)
-  make_dirs(dir_min_script)
+  remove_dir(DIR_MIN)
+  make_dirs(DIR_MIN_SCRIPT)
 
   for source in config.STYLES:
-    compile_style(os.path.join(dir_static, source), dir_min_style)
+    compile_style(os.path.join(DIR_STATIC, source), DIR_MIN_STYLE)
 
   for module in config.SCRIPTS:
     scripts = uniq(config.SCRIPTS[module])
     coffees = ' '.join([
-        os.path.join(dir_static, script)
+        os.path.join(DIR_STATIC, script)
         for script in scripts if script.endswith('.coffee')
       ])
 
-    pretty_js = os.path.join(dir_min_script, '%s.js' % module)
-    ugly_js = os.path.join(dir_min_script, '%s.min.js' % module)
+    pretty_js = os.path.join(DIR_MIN_SCRIPT, '%s.js' % module)
+    ugly_js = os.path.join(DIR_MIN_SCRIPT, '%s.min.js' % module)
     print_out('COFFEE MIN', ugly_js)
 
     if len(coffees):
-      os_execute(file_coffee, '--join -cp', coffees, pretty_js, append=True)
+      os_execute(FILE_COFFEE, '--join -cp', coffees, pretty_js, append=True)
     for script in scripts:
       if not script.endswith('.js'):
         continue
-      script_file = os.path.join(dir_static, script)
+      script_file = os.path.join(DIR_STATIC, script)
       merge_files(script_file, pretty_js)
-    os_execute(file_uglifyjs, pretty_js, '-cm', ugly_js)
+    os_execute(FILE_UGLIFYJS, pretty_js, '-cm', ugly_js)
     os.remove(pretty_js)
-
-  print_out('BABEL')
-  pybabel_extract()
-  pybabel_init_missing()
-  pybabel_update()
-  pybabel_compile()
   print_out('DONE')
 
-if args.init:
-  pybabel_init_missing()
 
-if args.pybabel_update:
-  pybabel_extract()
-  pybabel_init_missing()
-  pybabel_update()
-
-if args.locale:
-  pybabel_init(args.locale)
-
-if args.pybabel_compile:
-  pybabel_compile()
-
-if args.watch:
+def run_watch():
   print_out('WATCHING')
   make_lib_zip()
-  make_dirs(dir_dst)
+  make_dirs(DIR_DST)
 
   compile_all_dst()
   print_out('DONE', 'and watching for changes (Ctrl+C to stop)')
@@ -403,14 +381,16 @@ if args.watch:
     update_path_separators()
     compile_all_dst()
 
-if args.flush:
-  remove_dir(dir_storage)
+
+def run_flush():
+  remove_dir(DIR_STORAGE)
   print_out('STORAGE CLEARED')
 
-if args.start:
-  make_dirs(dir_storage)
-  clear = 'yes' if args.flush else 'no'
-  port = int(args.port)
+
+def run_start():
+  make_dirs(DIR_STORAGE)
+  clear = 'yes' if ARGS.flush else 'no'
+  port = int(ARGS.port)
   run_command = '''
       dev_appserver.py %s
       --host %s
@@ -419,5 +399,55 @@ if args.start:
       --storage_path=%s
       --clear_datastore=%s
       --skip_sdk_update_check
-    ''' % (DIR_MAIN, args.host, port, port + 1, dir_storage, clear)
+    ''' % (DIR_MAIN, ARGS.host, port, port + 1, DIR_STORAGE, clear)
   os.system(run_command.replace('\n', ' '))
+
+
+def run():
+  if len(sys.argv) == 1:
+    PARSER.print_help()
+    sys.exit(1)
+
+  os.chdir(os.path.dirname(os.path.realpath(__file__)))
+
+  update_path_separators()
+  update_missing_args()
+
+  if ARGS.clean_all:
+    run_clean_all()
+
+  install_dependencies()
+
+  if ARGS.clean:
+    run_clean()
+
+  if ARGS.minify:
+    pybabel_compile()
+    run_minify()
+
+  if ARGS.pybabel_init_missing:
+    pybabel_init_missing()
+
+  if ARGS.pybabel_locale:
+    pybabel_init(ARGS.pybabel_locale)
+
+  if ARGS.pybabel_update:
+    pybabel_extract()
+    pybabel_init_missing()
+    pybabel_update()
+
+  if ARGS.pybabel_compile:
+    pybabel_compile()
+
+  if ARGS.watch:
+    run_watch()
+
+  if ARGS.flush:
+    run_flush()
+
+  if ARGS.start:
+    run_start()
+
+
+if __name__ == '__main__':
+  run()


### PR DESCRIPTION
Suggestion for `run.py` to be applied when recent changes in `gae-init` are applied to `gae-init-babel`, in particular based on changes made in https://github.com/gae-init/gae-init/pull/95 _"Using bower package management for vendor libraries"_.

I've applied a `pybabel_` prefix to all translations oriented handling; and added the `pybabel_compile()` step to the `ARGS.minify` handling to ensure this is done before uploading. Previously, in 12.0 based `gae-init-babel`, the `minify` step also initialized, extracted, updated, and compiled translations; which might be a little too much automation; given that there could be many `fuzzy` and `""` (blank) translations.
