### PR TITLE
Reduce number of flags to those used

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -16,7 +16,8 @@
     },
     "flag-icon-css": {
       "less": "less/*.less",
-      "flag": "flags"
+      "flag/1x1": "flags/1x1/{gb,gr,pl,ru}.svg",
+      "flag/4x3": "flags/1x1/{gb,gr,pl,ru}.svg"
     },
     "font-awesome": {
       "less": "less/*.less",


### PR DESCRIPTION
Using `flag-icon-css` via `bower` as-is will include an extensive set of flags, which is perfect for applications that will or may use all of them. However, in `gae-init-babel` only a subset will be used; namely the flags that represent the configured locales (see `main/config.py` and `main/static/src/style/locale/less`). Therefore, this PR suggest reducing the number of flags deployed to GAE by specifying the relevant ones in the `bower.json` file. The downside to this approach is that it adds yet another place to consider when working with i18n and localization... it however does reduce the number of static files deployed to GAE a lot.
