### PR TITLE
Reducing get_locale overhead

### DIFF
--- a/main/auth.py
+++ b/main/auth.py
@@ -33,20 +33,24 @@ def check_locale(locale):
 
 @babel.localeselector
 def get_locale():
-  locale = flask.session.pop('locale', None)
-  if not locale:
-    locale = flask.request.cookies.get('locale', None)
+  try:
+    return flask.request.locale
+  except:
+    locale = flask.session.pop('locale', None)
     if not locale:
-      locale = flask.request.accept_languages.best_match(
-        matches=config.LOCALE.keys(),
-        default=config.LOCALE_DEFAULT)
-  return check_locale(locale)
+      locale = flask.request.cookies.get('locale', None)
+      if not locale:
+        locale = flask.request.accept_languages.best_match(
+          matches=config.LOCALE.keys(),
+          default=config.LOCALE_DEFAULT)
+    return check_locale(locale)
 
 
 @flask.request_started.connect_via(app)
 def request_started(sender, **extra):
-  flask.request.locale = get_locale()
-  flask.request.locale_html = get_locale().replace('_', '-')
+  locale = get_locale()
+  flask.request.locale = locale
+  flask.request.locale_html = locale.replace('_', '-')
 
 
 @app.route('/l/<path:locale>/')


### PR DESCRIPTION
Found that `auth/get_locale` was called 3 times on each request in `gae-init-babel`; and thus looked into the reasons why.

Adding a `traceback.print_stack(limit=5)` inside it showed that `auth/request_started` (associated with `@flask.request_started.connect_via(app)`) was calling it twice (easy to resolve... using local variable).

While the other call was due to `@babel.localeselector` being associated with `get_locale`; which seems to be okay (whatever makes Flask-Babel happy...) but clearly hinted at an opportunity to reduce overhead even more. Especially since the trace showed that the `@babel.localeselector` bound call (always?) follows the `@flask.request_started` call; which is why there now is a try-except to return first call result (if any).

This PR should thus improve efficiency, by eliminating one call and optimizing the typical flow of the two remaining calls trying to get the same thing in order (and not messing with that Flask and Flask-Babel stuff; assuming they are right to do so).
