### PR TITLE
Reduced get_locale overhead

### DIFF
--- a/main/auth.py
+++ b/main/auth.py
@@ -47,9 +47,8 @@ def get_locale():
 
 @flask.request_started.connect_via(app)
 def request_started(sender, **extra):
-  locale = get_locale()
-  flask.request.locale = locale
-  flask.request.locale_html = locale.replace('_', '-')
+  flask.request.locale = get_locale()
+  flask.request.locale_html = flask.request.locale.replace('_', '-')
 
 
 @app.route('/l/<path:locale>/')


### PR DESCRIPTION
As discussed in https://github.com/gae-init/gae-init-babel/pull/36, I've found that `auth/get_locale` was called 3 times on each request in `gae-init-babel`; and thus looked into the reasons why and how to improve.

Easy fix was to use a local variable in `request_started` to remove one of the three calls.

The other two calls are due to how Flask and Flask-Babel are used in the project (see https://github.com/gae-init/gae-init-babel/pull/36 for further details); and I suggest to simply keep that as-is, accepting the two subsequent calls to `get_locale`; but to make the second `@babel.localeselector`-based call more efficient by testing for that previous call result (in the same request).
