### PR TITLE
Remove duplicate libx path insertion

### DIFF
--- a/main/appengine_config.py
+++ b/main/appengine_config.py
@@ -3,7 +3,6 @@
 import os
 import sys
 
-sys.path.insert(0, 'libx')
 
 if os.environ.get('SERVER_SOFTWARE', '').startswith('Google App Engine'):
   sys.path.insert(0, 'lib.zip')


### PR DESCRIPTION
The last line of `appengine_config.py` is inserting `libx` into the path already (in `gae-init`), so no need to do it twice in `gae-init-babel`...
